### PR TITLE
Fix stash error

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -61,6 +61,7 @@ function show_git_info
 
     set --local LIMBO /dev/null
     set --local git_status (git status --porcelain 2> $LIMBO)
+    set --local git_stash (git stash list 2> $LIMBO)
     set --local dirty ""
 
     [ $status -eq 128 ]; and return  # Not a repository? Nothing to do
@@ -76,7 +77,7 @@ function show_git_info
     end
 
     # If there is stashed modifications on repository, add '^' to dirty
-    if not [ -z (git stash list) ]
+    if not [ -z (echo "$git_stash") ]
         set dirty "$dirty^"
     end
 


### PR DESCRIPTION
I was getting the following error and this is how I fixed it. 

I don't have a lot of experience with bash or fish so there may be a more elegant way to do this.

```
[: unexpected argument at index 3: 'stash@{1}: blah blah blah.'
~/.config/fish/functions/fish_prompt.fish (line 80):
    if not [ -z (git stash list) ]
       ^
in function 'show_git_info'
        called on line 45 of file ~/.config/fish/functions/fish_prompt.fish
in function 'fish_right_prompt'
in command substitution
```