### PR TITLE
Handle error on more than 1 git stashes

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -77,7 +77,7 @@ function show_git_info
     end
 
     # If there is stashed modifications on repository, add '^' to dirty
-    if not [ -z (echo "$git_stash") ]
+    if not [ -z (echo "$git_stash" | head -n1) ]
         set dirty "$dirty^"
     end
 


### PR DESCRIPTION
Currently it outputs this error when there's more than 1 stash
```
[: unexpected argument at index 2: 'stash@{1}: WIP on thanos-workspace: 2b5f47b fix errors'

/tmp/fish.4QoA2B/show_git_info.fish (line 21): 
    if not [ -z (git stash list) ]
       ^
in function 'show_git_info'
        called on line 45 of file ~/.config/fish/functions/fish_prompt.fish
in function 'fish_right_prompt'
in command substitution

(Type 'help [' for related documentation)
```